### PR TITLE
Update Chrome.pm

### DIFF
--- a/lib/Mojo/Chrome.pm
+++ b/lib/Mojo/Chrome.pm
@@ -40,6 +40,12 @@ sub detect_chrome_executable {
     $path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
     return $path if $path && -f $path && -x _;
   }
+    elsif ( $^O =~ /MSWin32|cygwin/ ) {
+        $path = qx{where.exe /R "c:\\Program Files (X86)" chrome.exe};
+        chomp $path;
+        $path =~ s/\r$//; # remove windows' \r
+        return $path if $path && -f $path && -x _;
+    }
 
   return undef;
 }


### PR DESCRIPTION
detect_chrome_executable now will work in Windows 10 (tested with strawberry perl 5.26.1, also on cygwin with correspondig perl 5.26.1)

- Example on Windows 10, strawberry perl 5.26.1:
```
PS C:\Users\xxxx\Mojo-Chrome> prove -l
t\basic.t ..... ok
t\from_url.t .. ok
t\tester.t .... ok
All tests successful.
Files=3, Tests=21,  5 wallclock secs ( 0.06 usr +  0.01 sys =  0.08 CPU)
Result: PASS
PS C:\Users\xxxx\Mojo-Chrome>
```